### PR TITLE
ci: audit with zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,29 @@ on:
     types:
       - checks_requested
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to checkout the repository
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,23 +4,32 @@ on:
     branches:
       - main
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
+    name: Release
     environment: npm
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      pull-requests: write
-      contents: write
+      id-token: write # for npm provenance
+      pull-requests: write # for changesets to create PRs
+      contents: write # for changesets to create releases
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           # provenance requires node>=24
           node-version: 24
@@ -31,7 +40,7 @@ jobs:
 
       - name: Create release pull request or publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: pnpm publish
         env:
@@ -39,8 +48,10 @@ jobs:
 
       - name: Send a Slack notification if a publish happens
         if: ${{ steps.changesets.outputs.hasChangesets == 'false' }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          export VERSION=$(jq -r '.version' package.json)
+          VERSION=$(jq -r '.version' package.json)
           curl -X POST -H 'Content-type: application/json'\
             --data '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":"npm에 `@portone/react-native-sdk` 버전 *v'"$VERSION"'* 가 배포되었습니다 :rocket:"}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"npm 페이지 보기"},"value":"show_npm_page","url":"https://www.npmjs.com/package/@portone/react-native-sdk/v/'"$VERSION"'","action_id":"show_npm_page"},{"type":"button","text":{"type":"plain_text","text":"체인지로그 보기"},"value":"show_changelog","url":"https://github.com/portone-io/react-native-sdk/blob/main/CHANGELOG.md","action_id":"show_changelog"}]}]}'\
-            ${{ secrets.SLACK_WEBHOOK_URL }}
+            "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## ci.yml

- **Added top-level `permissions: {}`**
  - Revokes all default GITHUB_TOKEN permissions at the workflow level. A compromised step cannot use the token to write to the repo, open PRs, or push packages.
- **Added `jobs.lint.permissions.contents: read`**
  - Re-grants only the read permission needed to checkout the repository. All other scopes remain denied.
- **Added `jobs.lint.name: Lint`**
  - Names the previously anonymous job, improving readability in the GitHub Actions UI and PR status checks.
- **Added top-level `concurrency` block** (`group: ${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`)
  - Ensures pushes to the same branch or updates to the same PR cancel stale in-progress runs, saving runner minutes and avoiding race conditions.
- **Pinned `actions/checkout@v5`** to `93cb6efe18208431cddfb8368fd83d5badbf9bfd`
  - Locks the exact code that runs, preventing a compromised or hijacked upstream tag from injecting malicious code. Version comment preserves readability.
- **Pinned `pnpm/action-setup@v4`** to `fc06bc1257f339d1d5d8b3a19a8cae5388b55320`
  - Same supply-chain protection as above.
- **Pinned `actions/setup-node@v6`** to `53b83947a5a98c8d113130e565377fae1a50d02f`
  - Same supply-chain protection as above.
- **Added `persist-credentials: false`** to the `actions/checkout` step
  - Stops the checkout action from saving the GITHUB_TOKEN in the local git config, eliminating credential leakage through artifacts or subsequent steps.

## release.yml

- **Added top-level `permissions: {}`**
  - The workflow's default token becomes unprivileged; only the `release` job receives the explicitly listed scopes.
  - If a future job is added, it won't silently inherit broad permissions.
- **Added explanatory comments to `jobs.release.permissions`** (`id-token: write # for npm provenance`, `pull-requests: write # for changesets to create PRs`, `contents: write # for changesets to create releases`)
  - Makes the rationale for each permission auditable without reading the action source.
- **Added `jobs.release.name: Release`**
  - Names the previously anonymous job for UI and status check clarity.
- **Added top-level `concurrency` block** (`group: ${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`)
  - Prevents overlapping release runs on rapid successive pushes to `main`, avoiding race conditions in changesets PR creation or duplicate npm publishes.
- **Pinned `actions/checkout@v5`** to `93cb6efe18208431cddfb8368fd83d5badbf9bfd`
  - Locks the exact code that runs against tag mutation supply-chain attacks.
- **Pinned `pnpm/action-setup@v4`** to `fc06bc1257f339d1d5d8b3a19a8cae5388b55320`
  - Same supply-chain protection as above.
- **Pinned `actions/setup-node@v6`** to `53b83947a5a98c8d113130e565377fae1a50d02f`
  - Same supply-chain protection as above.
- **Pinned `changesets/action@v1`** to `6a0a831ff30acef54f2c6aa1cbbc1096b066edaf` (v1.7.0)
  - The original `@v1` tag floats across all v1.x releases; pinning to the exact commit eliminates that ambiguity.
- **Added `persist-credentials: false`** to the `actions/checkout` step
  - Especially important here because this job has `contents: write` — a leaked token could push arbitrary commits to `main`.
- **Moved `${{ secrets.SLACK_WEBHOOK_URL }}` from inline `run:` interpolation to an `env:` block**, referenced as `"$SLACK_WEBHOOK_URL"` in the script
  - The original `${{ }}` form expanded the secret directly into the shell script source before bash parsed it
  - A malformed secret value could break out of the `curl` argument and execute arbitrary shell commands.
  - The `env:` approach passes the value through an environment variable, which bash treats as data, not code.
